### PR TITLE
Fix pagination edge case for header_style None

### DIFF
--- a/partials/components/post-list.hbs
+++ b/partials/components/post-list.hbs
@@ -47,7 +47,7 @@
                             {{/get}}
                         {{/match}}
                     {{else}}
-                        {{#get "posts" include="authors" limit="12"}}
+                        {{#get "posts" include="authors" limit=@config.posts_per_page}}
                             {{#foreach posts}}
                                 {{> "post-card" lazyLoad=true}}
                             {{/foreach}}


### PR DESCRIPTION
There was an issue when post count was >12 but <config.posts_per_page (and default is 15) where some posts were not visible on home (page 1) but "See all" not showing and page 2 not available.