### PR TITLE
Removed redundant get helpers

### DIFF
--- a/partials/components/post-list.hbs
+++ b/partials/components/post-list.hbs
@@ -23,35 +23,27 @@
                     {{#match @custom.header_style "Highlight"}}
                         {{#if @custom.show_featured_posts}}
                             {{#match posts.length ">=" 4}}
-                                {{#get "posts" include="authors" limit="16"}}
                                     {{#foreach posts from="5" limit="12"}}
                                         {{> "post-card" lazyLoad=true}}
                                     {{/foreach}}
-                                {{/get}}
                             {{/match}}
                         {{else}}
                             {{#match posts.length ">=" 10}}
-                                {{#get "posts" include="authors" limit="22"}}
                                     {{#foreach posts from="11" limit="12"}}
                                         {{> "post-card" lazyLoad=true}}
                                     {{/foreach}}
-                                {{/get}}
                             {{/match}}
                         {{/if}}
                     {{else match @custom.header_style "Magazine"}}
                         {{#match posts.length ">=" 7}}
-                            {{#get "posts" include="authors" limit="19"}}
                                 {{#foreach posts from="8" limit="12"}}
                                     {{> "post-card" lazyLoad=true}}
                                 {{/foreach}}
-                            {{/get}}
                         {{/match}}
                     {{else}}
-                        {{#get "posts" include="authors" limit="12"}}
-                            {{#foreach posts}}
+                            {{#foreach posts limit="12"}}
                                 {{> "post-card" lazyLoad=true}}
                             {{/foreach}}
-                        {{/get}}
                     {{/match}}
                 {{/match}}
 


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/CFR-32/update-source-theme-to-remove-extraneous-get-helpers

- The usage of `{{#get posts}}` which is wrapped around a `{{#foreach posts}}` doesn't appear to have any effect visually or within the loop, except it causes an additional, unneeded database request.
- This commit removes the redundant get helpers.