### PR TITLE
Update post-list.hbs added slash to page/2

### DIFF
--- a/partials/components/post-list.hbs
+++ b/partials/components/post-list.hbs
@@ -80,7 +80,7 @@
 
             {{#match pagination.pages ">" 1}}
                 <div class="gh-more is-title">
-                    <a href="{{@site.url}}/page/2">See all {{> "icons/arrow"}}</a>
+                    <a href="{{@site.url}}/page/2/">See all {{> "icons/arrow"}}</a>
                 </div>
             {{/match}}
         </main>


### PR DESCRIPTION
Because ghost automaticaly adds slashes to urls page/2 should have a slash at the end otherwise it is causing an extra redirect.