### PR TITLE
Remove weird pagination that read all posts regardless of the collections filter

### DIFF
--- a/partials/components/post-list.hbs
+++ b/partials/components/post-list.hbs
@@ -57,13 +57,6 @@
 
                 {{!-- All posts --}}
                 {{#match feed "index"}}
-                    {{#match pagination.page 2}}
-                        {{#get "posts" include="authors" limit=@config.posts_per_page as |recent|}}
-                            {{#foreach recent}}
-                                {{> "post-card"}}
-                            {{/foreach}}
-                        {{/get}}
-                    {{/match}}
                     {{#foreach posts}}
                         {{> "post-card" lazyLoad=true}}
                     {{/foreach}}


### PR DESCRIPTION
If I have a fairly standard collection that uses the index feed, it shows items on the second page as you scroll down that don't match it's filter. For example with the following `routes.yaml`:
```yaml
routes:
  /: home

collections:
  /blog/:
    permalink: /blog/{year}/{month}/{slug}/
    filter: primary_tag:blog
```
Then items that don't have their primary tag as `blog` still appear. This seems to be fairly directly caused by this unfiltered `#get` on page 2 in the source code, which I don't see any reason for... (obviously I may be missing something, please say!)