### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "gulp-uglify": "3.0.2",
         "gulp-zip": "5.1.0",
         "inquirer": "8.2.4",
-        "postcss": "8.2.13",
+        "postcss": "8.5.3",
         "postcss-easy-import": "4.0.0",
         "pump": "3.0.0"
     },


### PR DESCRIPTION
Pinning postcss to version 8.5.3 to address peer dependency issues with cssnano.  cssnano@5.1.12 requires postcss@^8.2.15