### PR TITLE
Adopt the shared Renovate theme preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,11 +210,5 @@
                 "group": "post"
             }
         }
-    },
-    "renovate": {
-        "extends": [
-            "@tryghost:theme",
-            "github>TryGhost/Themes:packages/theme-translations/renovate-config"
-        ]
     }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>TryGhost/renovate-config:theme.json5"
+  ]
+}


### PR DESCRIPTION
Adopts the shared Renovate preset `local>TryGhost/renovate-config:theme.json5` so dependency updates are kept current automatically.

Part of the `cleanrepos rollout renovate --type theme` batch. Review the `renovate.json` change and merge when ready.
