### PR TITLE
Localized post dates to respect the publication language

### DIFF
--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -39,7 +39,7 @@
                     <span class="gh-card-author">{{{t "By {authors}" authors=(authors autolink="false" separator=", ") }}}</span>
                 {{/if}}
                 {{#if @custom.show_publish_date}}
-                    <time class="gh-card-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="DD MMM YYYY"}}</time>
+                    <time class="gh-card-date" datetime="{{date format="YYYY-MM-DD"}}">{{date}}</time>
                 {{/if}}<!--
          --></footer>
         </div>

--- a/post.hbs
+++ b/post.hbs
@@ -34,7 +34,7 @@
                         <div class="gh-article-meta-wrapper">
                             <h4 class="gh-article-author-name">{{authors}}</h4>
                             <div class="gh-article-meta-content">
-                                <time class="gh-article-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="DD MMM YYYY"}}</time>
+                                <time class="gh-article-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date}}</time>
                                 {{#if reading_time}}
                                     <span class="gh-article-meta-length"><span class="bull">—</span> {{reading_time minute=(t "1 min read") minutes=(t "% min read")}}</span>
                                 {{/if}}


### PR DESCRIPTION
Post and post-card dates were hardcoded to `format="DD MMM YYYY"`, which ignores
the site's Publication Language. Because only the month name is localized by the
`date` helper, non-English sites got an awkward mix — e.g. a Korean site rendered
`04 7월 2026`, keeping Western day-month-year ordering.

Dropping the explicit format lets the `date` helper use its locale-aware default
(`ll`), so the whole date — ordering, separators and month name — follows the
site's Publication Language:

| Publication Language | Before (`DD MMM YYYY`) | After (`{{date}}` → `ll`) |
|---|---|---|
| English | 04 Jul 2026 | Jul 4, 2026 |
| Korean  | 04 7월 2026 | 2026년 7월 4일 |

The machine-readable ISO value on the `datetime` attribute is unchanged.
