### PR TITLE
Renamed CI gate job to the org-standard "Required checks pass"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
 
       - run: pnpm test:ci
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Branch protection on this repo currently requires the status check named exactly `All tests pass`. Requiring a repo-specific or legacy check name couples the ruleset to this workflow's job naming: rename the job (or restructure the matrix) and the required check silently stops existing, blocking every PR.

The org is standardizing every repository on a single stable aggregator check named `Required checks pass` — one job that `needs` every job that must pass and fails if any of them failed or was cancelled. That gives every ruleset one uniform, rename-proof target.

## What

- Renamed the gate job `all-tests-pass` / `All tests pass` → `required-checks-pass` / `Required checks pass`
- Coverage unchanged: the gate still depends on the same `test` job the old gate covered
- The workflow already had top-level `permissions: contents: read`

## Note on merging

The branch ruleset is being updated in the same pass to require the new check context, so this PR must go green on `Required checks pass` before merge. Do not merge until the ruleset swap is confirmed.