### PR TITLE
Add scheduled workflow to sync from TryGhost/Source upstream

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,138 @@
+# TryGhost/Source (upstream) の更新を検知し、main へのマージを自動で試みるワークフロー。
+# マージがコンフリクトなく完了した場合のみ、テスト実行結果を添えて Pull Request を自動作成する。
+# コンフリクトが発生した場合は Issue を作成し、手動対応を促す。
+name: Sync upstream
+
+on:
+  schedule:
+    # 毎週月曜 9:00 UTC に実行
+    - cron: "0 9 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  sync:
+    name: Sync upstream
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote and fetch
+        run: |
+          git remote add upstream https://github.com/TryGhost/Source.git
+          git fetch upstream main
+
+      - name: Check for new upstream commits
+        id: check
+        run: |
+          if git merge-base --is-ancestor upstream/main HEAD; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for an existing open sync PR
+        id: existing_pr
+        if: steps.check.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count=$(gh pr list --base main --state open --search "Sync upstream: TryGhost/Source in:title" --json number --jq 'length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Attempt merge into a sync branch
+        if: steps.check.outputs.has_changes == 'true' && steps.existing_pr.outputs.count == '0'
+        id: merge
+        run: |
+          branch="sync/upstream-$(date -u +%Y%m%d)-${{ github.run_number }}"
+          git checkout -b "$branch"
+          if git merge upstream/main --no-edit; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            git merge --abort
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+        if: steps.merge.outputs.conflict == 'false'
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        if: steps.merge.outputs.conflict == 'false'
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Run tests against the merged result
+        if: steps.merge.outputs.conflict == 'false'
+        id: test
+        run: |
+          pnpm install --frozen-lockfile
+          if pnpm test:ci; then
+            echo "passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push sync branch
+        if: steps.merge.outputs.conflict == 'false'
+        run: git push origin "${{ steps.merge.outputs.branch }}"
+
+      - name: Create pull request
+        if: steps.merge.outputs.conflict == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ steps.test.outputs.passed }}" = "true" ]; then
+            status_note="テスト (\`pnpm test:ci\`) は成功しています。"
+          else
+            status_note="⚠️ テスト (\`pnpm test:ci\`) が失敗しています。マージ前に内容を確認してください。"
+          fi
+          gh pr create \
+            --title "Sync upstream: TryGhost/Source" \
+            --base main \
+            --head "${{ steps.merge.outputs.branch }}" \
+            --body "TryGhost/Source の最新コミットを upstream/main から main へマージしました。${status_note}"
+
+      - name: Check for an existing open conflict issue
+        id: existing_issue
+        if: steps.merge.outputs.conflict == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count=$(gh issue list --state open --search "upstream(TryGhost/Source)の自動マージに失敗しました in:title" --json number --jq 'length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Notify merge conflict
+        if: steps.merge.outputs.conflict == 'true' && steps.existing_issue.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_BODY: |
+            TryGhost/Source の最新コミットを main に自動マージできませんでした。コンフリクトが発生しているため、手動で解決してください。
+
+            ```bash
+            git remote add upstream https://github.com/TryGhost/Source.git
+            git fetch upstream
+            git checkout -b sync/upstream-manual
+            git merge upstream/main
+            # コンフリクトを解消してコミット
+            git push -u origin sync/upstream-manual
+            ```
+        run: |
+          gh issue create \
+            --title "upstream(TryGhost/Source)の自動マージに失敗しました" \
+            --body "$ISSUE_BODY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,22 @@ pnpm zip
 
 Run the test command before opening a PR when theme files, generated assets, dependencies, or CI change.
 
+## Upstream sync
+
+This repository is a fork of [TryGhost/Source](https://github.com/TryGhost/Source), customized for personal use. The `.github/workflows/sync-upstream.yml` workflow checks upstream weekly (and on manual dispatch): if `upstream/main` has new commits, it merges them into a `sync/upstream-*` branch, runs `pnpm test:ci` against the merged result, and opens a PR against `main` with the test outcome noted in the description. If the merge conflicts, it opens an issue instead of a PR.
+
+The repository's "Workflow permissions" setting (Settings > Actions > General) must allow read/write for `GITHUB_TOKEN`, or the workflow cannot push branches or create PRs/issues.
+
+To sync manually:
+
+```bash
+git remote add upstream https://github.com/TryGhost/Source.git
+git fetch upstream
+git checkout -b sync/upstream-manual
+git merge upstream/main
+# resolve conflicts, then commit and push
+```
+
 ## Boundaries
 
 - Edit source CSS, JavaScript, Handlebars templates, partials, and package metadata intentionally.


### PR DESCRIPTION
## Summary
- TryGhost/Source (upstream) の更新に追従できるよう、`.github/workflows/sync-upstream.yml` を追加
- 週次(毎週月曜 9:00 UTC)および手動実行(`workflow_dispatch`)でupstream/mainをチェックし、新規コミットがあればmainへのマージを試行
- マージがコンフリクトなく完了した場合は `pnpm test:ci` を実行し、結果を明記した上でPRを自動作成
- コンフリクトが発生した場合はPRの代わりにIssueを作成し、手動対応の手順を案内
- 重複実行防止として、既存のオープンなsync PR/Issueがあれば新規作成をスキップ
- ローカルにも `upstream` remote (`https://github.com/TryGhost/Source.git`) を登録済み
- `AGENTS.md` に upstream sync の運用方針とリポジトリ設定(`GITHUB_TOKEN` の read/write権限が必要)を追記

## Test plan
- [x] `pnpm test:ci`(zip + gscan)がローカルで成功することを確認
- [x] `actionlint` でワークフローYAMLの構文・シェルスクリプトを検証(エラーなし)
- [ ] マージ後、GitHubリポジトリの Settings > Actions > General で「Read and write permissions」が有効になっていることを確認
- [ ] `workflow_dispatch` で一度手動実行し、実際にPR/Issueが作成されることを確認