### PR TITLE
fix: hide Featured section when there are no featured posts

### DIFF
--- a/partials/components/featured.hbs
+++ b/partials/components/featured.hbs
@@ -1,14 +1,16 @@
 {{#if showFeatured}}
     {{#get "posts" filter="featured:true" include="authors" limit=limit as |featured|}}
-        <section class="gh-featured gh-outer">
-            <div class="gh-featured-inner gh-inner">
-                <h2 class="gh-featured-title">{{t "Featured"}}</h2>
-                <div class="gh-featured-feed">
-                    {{#foreach featured}}
-                        {{> "post-card" imageSizes="80px"}}
-                    {{/foreach}}
+        {{#if featured}}
+            <section class="gh-featured gh-outer">
+                <div class="gh-featured-inner gh-inner">
+                    <h2 class="gh-featured-title">{{t "Featured"}}</h2>
+                    <div class="gh-featured-feed">
+                        {{#foreach featured}}
+                            {{> "post-card" imageSizes="80px"}}
+                        {{/foreach}}
+                    </div>
                 </div>
-            </div>
-        </section>
+            </section>
+        {{/if}}
     {{/get}}
 {{/if}}


### PR DESCRIPTION
## Summary
- With \`show_featured_posts\` enabled but no featured posts, Source still rendered an empty Featured heading/section.
- Wrap the section in \`{{#if featured}}\` so it only appears when the query returns posts (same approach as Dawn).

## Test plan
- [ ] Enable featured posts in Source design settings with zero featured posts → Featured block is gone
- [ ] Mark a post featured → Featured block appears with that post

Closes #95
