### PR TITLE
Apply the 72-hour pnpm baseline to Source

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,8 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml',
+            // Keep pnpm-workspace.yaml so standalone installs inherit
+            // the supply-chain policy.
             '!AGENTS.md',
             '!CLAUDE.md',
             '!gulpfile.js'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+strictDepBuilds: true
+minimumReleaseAge: 4320
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan through gscan; not needed to build, zip, or scan the theme.
   dtrace-provider: false


### PR DESCRIPTION
## What changed

- Added `minimumReleaseAge: 4320` to enforce an explicit 72-hour dependency cooldown.
- Added `strictDepBuilds: true` so unapproved lifecycle scripts fail installation.
- Added `blockExoticSubdeps: true` so transitive dependencies cannot resolve from exotic Git or tarball sources.
- Preserved the existing package-wide `dtrace-provider: false` denial.
- Kept the build permission surface empty; there are no `allowBuilds: true` entries.
- Retained `pnpm-workspace.yaml` in the generated standalone `source.zip` so standalone installs receive the same policy.

## Why

Source is consumed in two forms: Ghost updates it as a full git submodule, and Source releases a standalone theme archive. The submodule path already carries the root configuration, but the zip task explicitly removed `pnpm-workspace.yaml`, leaving the standalone artifact without the repository's dependency-install policy.

Both paths now retain the same explicit 72-hour and fail-closed pnpm controls without permitting any dependency lifecycle scripts.

This is the Source portion of [PLA-321](https://linear.app/ghost/issue/PLA-321/make-the-72-hour-pnpm-cooldown-explicit-across-first-party-themes).

## Impact

There is no theme runtime behavior change. Newly published dependencies wait 72 hours, unapproved build scripts fail installation, and exotic transitive sources are blocked. The standalone theme zip gains the small pnpm policy manifest; it continues to exclude `pnpm-lock.yaml` and other development-only files.

## Validation

- `corepack pnpm --version` (`11.19.0`)
- Effective pnpm settings verified with `pnpm config get`
- `corepack pnpm install --frozen-lockfile` (751 lockfile entries passed supply-chain policy verification)
- `corepack pnpm build`
- `corepack pnpm test:ci` (zip generation and fatal gscan)
- Standalone fatal gscan after restoring tracked build artifacts
- Verified `source.zip` contains a byte-identical `pnpm-workspace.yaml` and excludes `pnpm-lock.yaml`
- Verified the effective allow map remains only `dtrace-provider: false`
- `git diff --check`