### PR TITLE
Updated Source release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,21 +50,32 @@ pnpm zip
 
 # Publishing a release
 
-Releases are shipped in two steps. First bump the version — this updates `package.json` and creates the matching commit and `v<version>` git tag:
+Releases are shipped from an up-to-date, clean `main` branch in two steps. Before starting, configure `GST_TOKEN` with a GitHub token that can create releases in `TryGhost/Source`.
+
+First bump the version. This updates `package.json`, then creates a commit and annotated `v<version>` git tag:
 
 ```bash
 # pick one of: patch | minor | major (or an explicit version, e.g. 1.8.0)
 pnpm version minor
 ```
 
-Then run `ship`, which checks the working tree is clean, pushes the commit and tag, and drafts the GitHub release from the changelog:
+Then run `ship`:
 
 ```bash
 pnpm ship
 ```
 
+`pnpm ship`:
+
+1. Builds the theme zip and runs GScan.
+2. Refuses to continue if the working tree is not clean after the build.
+3. Pushes the version commit and tag.
+4. Prompts for the minimum compatible Ghost version and creates a draft GitHub release with the generated changelog.
+
+Review and publish the draft GitHub release after the command completes. The pushed theme tag, rather than the GitHub release, is what the next Ghost release uses when updating its bundled Source theme.
+
 > [!NOTE]
-> `pnpm version` must be run first — unlike the old `yarn version`, `pnpm version` is not interactive and `pnpm ship` no longer performs the bump itself.
+> `pnpm version` requires an explicit version or bump type. Run it before `pnpm ship`; the ship command does not perform the bump itself.
 
 # PostCSS Features Used
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ The `zip` Gulp task packages the theme files into `dist/<theme-name>.zip`, which
 pnpm zip
 ```
 
+# Publishing a release
+
+Releases are shipped in two steps. First bump the version — this updates `package.json` and creates the matching commit and `v<version>` git tag:
+
+```bash
+# pick one of: patch | minor | major (or an explicit version, e.g. 1.8.0)
+pnpm version minor
+```
+
+Then run `ship`, which checks the working tree is clean, pushes the commit and tag, and drafts the GitHub release from the changelog:
+
+```bash
+pnpm ship
+```
+
+> [!NOTE]
+> `pnpm version` must be run first — unlike the old `yarn version`, `pnpm version` is not interactive and `pnpm ship` no longer performs the bump itself.
+
 # PostCSS Features Used
 
 - Autoprefixer - Don't worry about writing browser prefixes of any kind, it's all done automatically with support for the latest 2 major versions of every browser.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "pretest": "pnpm zip",
         "pretest:ci": "pnpm zip",
         "preship": "pnpm test",
-        "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then pnpm version && git push --follow-tags; else echo \"Uncommitted changes found.\" && exit 1; fi",
+        "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then git push --follow-tags; else echo \"Uncommitted changes found.\" && exit 1; fi",
         "postship": "git fetch && gulp release"
     },
     "packageManager": "pnpm@11.22.0",


### PR DESCRIPTION
## What changed

- documented Source's complete two-step release workflow
- made the version bump an explicit `pnpm version <bump>` step
- changed `pnpm ship` to push the already-created commit and tag
- documented `GST_TOKEN`, theme validation, the Ghost compatibility prompt, and draft release publication
- clarified that the pushed theme tag—not the GitHub Release object—is what Ghost consumes

## Why

Source's ship script was mechanically migrated from `yarn version` to bare `pnpm version`. In pnpm 11, the version command requires an explicit semver version or bump type, so the old script exits before pushing.

The corrected workflow matches pnpm's behavior: `pnpm version minor` creates the version commit and annotated tag, while `pnpm ship` runs the pre/post lifecycle scripts, validates the theme, pushes the commit/tag, and creates the draft GitHub release.

## Validation

- verified against the official pnpm 11 `version` and `run` behavior
- isolated release audit with Source's actual scripts and pnpm 11.22.0
- confirmed bare `pnpm version` exits with `ERR_PNPM_INVALID_VERSION_BUMP`
- confirmed `pnpm version minor` updates `package.json`, commits, and creates `v1.8.0`
- confirmed `pnpm ship` runs `preship`, pushes the commit/tag, and runs `postship`
- `pnpm install --frozen-lockfile`
- `pnpm test:ci`