### PR TITLE
Fixed blurry images in post feeds

### DIFF
--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -9,7 +9,7 @@
                             {{img_url feature_image size="l" format="webp"}} 960w,
                             {{img_url feature_image size="xl" format="webp"}} 1200w,
                             {{img_url feature_image size="xxl" format="webp"}} 2000w"
-                    sizes="{{#if imageSizes}}{{imageSizes}}{{else}}320px{{/if}}"
+                    sizes="{{#if imageSizes}}{{imageSizes}}{{else}}{{#if lazyLoad}}auto, (max-width: 1199px) 100vw, 980px{{else}}320px{{/if}}{{/if}}"
                     src="{{img_url feature_image size="m"}}"
                     alt="{{#if feature_image_alt}}{{feature_image_alt}}{{else}}{{title}}{{/if}}"
                     {{#if lazyLoad}}loading="lazy"{{/if}}


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/DES-1376/source-theme-blurry-image, https://linear.app/ghost/issue/DES-1427/tag-pages-image-srcset-issue

Use native `sizes="auto"` for lazy-loaded post card images so the browser selects a source matching the card's rendered width. Preserve explicit `imageSizes` values and the existing 320px fallback for eager cards.
